### PR TITLE
Error message not decoded at handshake

### DIFF
--- a/mysql-protocol.r
+++ b/mysql-protocol.r
@@ -872,6 +872,7 @@ make root-protocol [
 			pl/buffer: make binary! pl/buf-size
 			pl/cache: make binary! pl/buf-size
 			pl/conv-list: copy*/deep conv-model
+			pl/capabilities: []
 		]
 
 		parse/all read-packet port [


### PR DESCRIPTION
Due to a not already initialized port/locals/capabilities to a block!, the read-packet function throw error in the protocol code :
```
** Script Error: find expected series argument of type: series object port bitset
** Where: read-packet
** Near: parse/all next pl/buffer case [
    find pl/capabilities 'protocol-41 [
        [
            read-int (pl/error-code: i...
```
